### PR TITLE
Explicitly require Element.js

### DIFF
--- a/lib/Stanza.js
+++ b/lib/Stanza.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var inherits = require('inherits')
-var Element = require('ltx').Element
+var Element = require('ltx/lib/Element')
 
 function Stanza (name, attrs) {
   Element.call(this, name, attrs)


### PR DESCRIPTION
Hello!

The project I'm working on is intended to work in browsers, so bundle size is important to me.

In that project I use [`StreamParser`](https://github.com/node-xmpp/core/blob/master/lib/StreamParser.js) from `node-xmpp/core`, which is quite small by itself. The two big dependencies of it is this module and `node-xmpp/ltx`.

[ltx](https://github.com/node-xmpp/ltx) is great, but it exports more stuff that one may actually need (I mean, 5 parsers?). That makes browser bundles much bigger than they could be.

I've made a [separate PR](https://github.com/node-xmpp/core/pull/90) at `node-xmpp/core` to reduce `StreamParser`'s bundled size, but it need this PR to be merged to gain full power.

---

Requiring files by path makes projects more fragile, but I guess it's fine as long as both projects are maintained by the same people. The better solution would be using [ES6 exports](https://github.com/rollup/rollup/wiki/jsnext:main), so bundlers like `rollup` or `webpack 2` could tree-shake the project to a minimal size. But it takes a bit more work than this, so I'll leave it to your consideration.